### PR TITLE
Improve speed for namespaced maps

### DIFF
--- a/scss/pack/seed-config/mixins/_config.scss
+++ b/scss/pack/seed-config/mixins/_config.scss
@@ -27,7 +27,7 @@
     }
 
     $named_map: ($namespace: _deep-extend($named_map, $maps...));
-    $global_config: _deep-extend($map, $named_map);
+    $global_config: map-merge($map, $named_map);
   }
   @else {
     $global_config: _deep-extend($map, $maps...);


### PR DESCRIPTION
## Updates 

### Improve speed for namespaced maps 🏃 💨 

A tiny but important update! Changed the merge method for namespaced maps from `_deep-extend` -> `map-merge` when updating the global variable.

This DRAMATICALLY reduces the compile speeds of Sass. Our test times reduced from `3s` to around `400ms`.